### PR TITLE
Django 2.0 compliant

### DIFF
--- a/oh_proj_management/urls.py
+++ b/oh_proj_management/urls.py
@@ -1,25 +1,12 @@
-"""oh_proj_management URL Configuration
+#oh_proj_management URL Configuration
 
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.11/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
-"""
-from django.conf.urls import url
+from django.urls import path
 from django.contrib import admin
 
 from .views import HomeView, LoginView
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^$', HomeView.as_view(), name='home'),
-    url(r'^login/?$', LoginView.as_view(), name='login'),
+    path('admin/', admin.site.urls),
+    path('', HomeView.as_view(), name='home'),
+    path('login/', LoginView.as_view(), name='login'),
 ]


### PR DESCRIPTION
I noticed that the project was upgraded to Django 2.0 but the URL syntax didn't upgrade. Since Django 2.0 has introduced the new simplified URL routing syntax free from regular expressions, I have updated the same in this commit. The old `django.conf.urls.url()` is likely to be deprecated in future releases.

A suggestion not included in the commit: 
If we add more apps in addition to project_admin, we can add the `urls.py` specific to the app inside the
app folder and then `include()` them in root URLconf. This would improve the organization of URLs. :)