### PR TITLE
Add error handling for expired master tokens

### DIFF
--- a/project_admin/views.py
+++ b/project_admin/views.py
@@ -39,7 +39,7 @@ class HomeView(TemplateView):
         if req.status_code == 200:
             return req.json()
         else:
-            messages.error('Token not valid. Maybe a fresh one is needed?')
+            messages.error(self.request, 'Token not valid. Maybe a fresh one is needed?')
             return None
 
 
@@ -53,6 +53,14 @@ class LoginView(FormView):
         req_url = ("https://www.openhumans.org/api/direct-sharing/project/?access_token={}".format(token))
         params = {'token': token}
         r = requests.get(req_url, params=params).json()
-        Project.objects.update_or_create(id=r['id'], defaults=r)
-        self.request.session['master_access_token'] = token
+        try:
+            Project.objects.update_or_create(id=r['id'], defaults=r)
+            self.request.session['master_access_token'] = token
+        except Exception as e:
+            # Handle expired master tokens, or serve error message
+            if 'Expired token' in r['detail']:
+                messages.error(self.request, 'Token has expired. Refresh your token in the project management interface.')
+            else:
+                messages.error(self.request, e)
+        
         return redirect('home')


### PR DESCRIPTION
If you try to use an expired master access token, an error, `KeyError at /login/` would appear. This PR adds proper error handling via `messages` (which appear/render on the page after submission) if an expired access token is entered into the token field.

If you would like to test with a expired token:
```LSlmNuHMf2DWgYwev80QV8lDZ3EfOhKCndRfdXJG5Hv76A0CE1BNMAaGL2q86EoM``` 
This is an expired token for an (empty) test project I created before.

![](https://cl.ly/1Y0S0V331f31/Screen%20Shot%202018-02-22%20at%204.42.08%20PM.png)