### PR TITLE
fix issues with tests, add cassette for members test

### DIFF
--- a/project_admin/cassettes/test_members_request.yaml
+++ b/project_admin/cassettes/test_members_request.yaml
@@ -7,18 +7,18 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://www.openhumans.org/api/direct-sharing/project/members/?access_token=XitlFDXBqm5TRK8Vuh3Ey2cDFdiTWz7amKpot97H9Xfgak1qpvray0b0arQhvpEP
+    uri: https://www.openhumans.org/api/direct-sharing/project/members/?access_token=ACCESSTOKEN
   response:
     body: {string: '{"count":1,"next":null,"previous":null,"results":[{"created":"2016-05-19T22:16:39.842587Z","project_member_id":"07876706","message_permission":false,"sources_shared":["direct-sharing-11"],"data":[]}]}'}
     headers:
       Allow: ['GET, HEAD, OPTIONS']
-      Cache-Control: ['must-revalidate, no-store, no-cache, max-age=0']
+      Cache-Control: ['max-age=0, no-cache, no-store, must-revalidate']
       Connection: [close]
       Content-Language: [en]
       Content-Type: [application/json]
-      Date: ['Tue, 20 Mar 2018 05:42:48 GMT']
-      Expires: ['Tue, 20 Mar 2018 05:42:48 GMT']
-      Last-Modified: ['Tue, 20 Mar 2018 05:42:48 GMT']
+      Date: ['Fri, 06 Apr 2018 04:14:49 GMT']
+      Expires: ['Fri, 06 Apr 2018 04:14:49 GMT']
+      Last-Modified: ['Fri, 06 Apr 2018 04:14:49 GMT']
       Server: [Cowboy]
       Vary: ['Accept, Accept-Language, Cookie']
       Via: [1.1 vegur]

--- a/project_admin/cassettes/test_valid_token.yaml
+++ b/project_admin/cassettes/test_valid_token.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://www.openhumans.org/api/direct-sharing/project/?access_token=XitlFDXBqm5TRK8Vuh3Ey2cDFdiTWz7amKpot97H9Xfgak1qpvray0b0arQhvpEP
+    uri: https://www.openhumans.org/api/direct-sharing/project/?access_token=ACCESSTOKEN
   response:
     body: {string: '{"active":true,"approved":false,"authorized_members":1,"badge_image":"https://open-humans-production.s3.amazonaws.com/direct-sharing/badges/None/pet-badge.png","contact_email":"support@openhumans.org","id":12,"id_label":"direct-sharing-12","info_url":"https://www.example.com","is_academic_or_nonprofit":true,"is_study":false,"leader":"Mad
         Price Ball","long_description":"NOT A REAL PROJECT. This project is set up

--- a/project_admin/tests.py
+++ b/project_admin/tests.py
@@ -4,21 +4,26 @@ import requests
 from django.urls import reverse
 from django.conf import settings
 
+FILTERSET = [('access_token', 'ACCESSTOKEN')]
+
+my_vcr = vcr.VCR(path_transformer=vcr.VCR.ensure_suffix('.yaml'), 
+                 cassette_library_dir='project_admin/cassettes',
+                 filter_headers=[('Authorization', 'XXXXXXXX')],
+                 filter_query_parameters=FILTERSET,
+                 filter_post_data_parameters=FILTERSET)
 
 class ProjectTest(TestCase):
     def setUp(self):
-        self.token = 'XitlFDXBqm5TRK8Vuh3Ey2cDFdiTWz7amKpot97H9Xfgak1qpvray0b0arQhvpEP'
+        settings.DEBUG = True
+        self.token = 'ACCESSTOKEN'
         self.url = 'https://www.openhumans.org/api/direct-sharing/project/members/?access_token={}'.format(
                     self.token)
 
-    @vcr.use_cassette('tests/members.yml')
+    @my_vcr.use_cassette()
     def test_members_request(self):
         """memebers list API"""
         response = requests.get(self.url)
         self.assertEqual(response.status_code, 200)
-
-
-my_vcr = vcr.VCR(path_transformer=vcr.VCR.ensure_suffix('.yaml'), cassette_library_dir='project_admin/cassettes')
 
 
 class LoginTest(TestCase):
@@ -26,7 +31,7 @@ class LoginTest(TestCase):
     def setUp(self):
         settings.DEBUG = True
         self.invalid_token = 'INVALID_TOKEN'
-        self.master_token = 'XitlFDXBqm5TRK8Vuh3Ey2cDFdiTWz7amKpot97H9Xfgak1qpvray0b0arQhvpEP'
+        self.master_token = 'ACCESSTOKEN'
         self.project_info_url = 'https://www.openhumans.org/api/direct-sharing/project/?access_token={}'
 
     @my_vcr.use_cassette()
@@ -41,6 +46,7 @@ class LoginTest(TestCase):
         response = requests.get(request_url)
         self.assertEqual(response.status_code, 200)
 
+    @my_vcr.use_cassette()
     def test_login_success(self):
         response = self.client.post(reverse('login'), {'token': self.master_token}, follow=True)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
There were a few issues from the last merged PR that I missed. This fixes a few token remnants and adds a proper cassette for `test_members_request`