### PR TITLE
fix overflowing modals

### DIFF
--- a/project_admin/static/project_admin/main.css
+++ b/project_admin/static/project_admin/main.css
@@ -1,0 +1,8 @@
+.modal-dialog{
+    position: relative;
+    display: table; /* This is important */
+    overflow-y: auto;
+    overflow-x: auto;
+    width: auto;
+    min-width: 300px;
+}

--- a/project_admin/templates/project_admin/files_modal_body.html
+++ b/project_admin/templates/project_admin/files_modal_body.html
@@ -2,9 +2,9 @@
 <table class="table">
   <thead>
   <tr>
-    <th style="width: 60%">Name</th>
-    <th style="width: 20%">Source</th>
-    <th style="width: 20%">Action</th>
+    <th>Name</th>
+    <th>Source</th>
+    <th>Action</th>
   </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Modals could overflow if e.g. group names or file names were too long. This dynamically adjusts the width to the correct amount.