### PR TITLE
Add URL to web demo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Read [this issue string](https://github.com/OpenHumans/open-humans/issues/690) f
  * In a browser, go to http://127.0.0.1:8000/
  * Before commiting run `flake8` and fix PEP8 warnings.
 
+## Demo web version
+
+https://oh-projectmanagement.herokuapp.com/login/ 
+
 ## Contributing
 
 ### Tips


### PR DESCRIPTION
(Note - web demo version seems to be not working right now, likely due to some changes on the OH side, but parking the URL here regardless so others can find it in the future)